### PR TITLE
Total time tracking

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,16 +1,22 @@
 $(function () {
   var app = {
     authListener: notificationService.addObserver('AUTH_SIGNIN', this, handleSignIn),
-    signOutListener: notificationService.addObserver('AUTH_SIGNOUT', this, handleSignOut)
+    signOutListener: notificationService.addObserver('AUTH_SIGNOUT', this, handleSignOut),
+    getTimeListener: notificationService.addObserver('TIME_FETCHED', this, handleTime),
   }
 
   function handleSignIn() {
     console.log('user signed in');
+    // calculateTotalTime();
   }
 
   function handleSignOut() {
     // call methods related to auth sign out
     signInDisplay();
+  }
+
+  function handleTime() {
+    data.calculateTotalTime();
   }
 
   function signInDisplay() {
@@ -55,10 +61,14 @@ $(function () {
 
   $(".codeTimeStart").on("click", function () {
     data.userStartTime();
+    data.createTimeInstance();
+    data.updateTime("start");
   })
 
   $(".codeTimeStop").on("click", function () {
     data.userStopTime();
+    data.updateTime("stop");
+    data.getTime();
   })
 
   // click submit, append message to message board
@@ -114,5 +124,4 @@ $(function () {
   }
 
   generateDummyChart();
-
 });

--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -12,7 +12,6 @@ var data = {
     createUser: function (email) {
         database.ref("users/" + auth.uid + "/").set(email);
     },
-
     userStartTime: function () {
         var userId = auth.uid;
         if (auth.uid) {
@@ -33,5 +32,38 @@ var data = {
           database.ref("codeTime/users/" + userId + "/stoppedAt").set(firebase.database.ServerValue.TIMESTAMP);
       }
     },
+    timeInstance: {
+        id: ""
+    },
+    createTimeInstance: function() {
+        this.timeInstance.id = database.ref("time/users/" + auth.uid + "/").push({}).key;
 
+        console.log("Current time instance: " + this.timeInstance.id);
+    },
+    updateTime: function(action) {
+        var timestamp = moment().format("YYYY-MM-DDTHH:mm:ss");
+        var timeObject = {};
+
+        timeObject[action] = timestamp;
+        
+        database.ref("time/users/" + auth.uid + "/" + this.timeInstance.id + "/").update(timeObject);
+    },
+    timeObject: {},
+    getTime: function() {
+        firebase.database().ref('time/users/' + auth.uid + "/" + this.timeInstance.id + "/")
+            .once('value', function (snapshot) {
+                data.timeObject = snapshot.val();
+                
+                // Must use notification service since to trigger synchronous event
+                notificationService.postNotification('TIME_FETCHED', null);
+        });
+    },
+    totalTime: "",
+    calculateTotalTime: function() {
+        var start = moment(this.timeObject.start);
+        var stop = moment(this.timeObject.stop);
+
+        this.totalTime = stop.diff(start, "minutes");
+        console.log(stop.diff(start, "seconds"));
+    }
 }


### PR DESCRIPTION
First version: creates a time instance in Firebase, for example:
```
{
  time: {
    users: {
      df64t2NaOVR8Izlmyc1WbnJur0R2: {
        -LdbeiwYd4W55iPwpO84: {
          start: "2019-04-29T00:56:56"
          stop: "2019-04-29T00:56:57"
        }
      }
    }
  }
}
```
Stores start when start button is clicked, and stores stop when stop button is clicked. Both using Moment JS to the millisecond. 

Added data.getTime() to stop button in order to fetch time instance from Firebase, in order to calculate total time. Since the calculation is synchronous, we must wait for the event to finish before doing the calculation, so a notification is created to handle this event. data.calculateTotalTime() calculates total time in minutes between start and stop (console logs into seconds for proof).

Next steps are to aggregate time instances and calculate time instances based on filters (months, days, hours).