### PR TITLE
Total time tracking

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -16,7 +16,7 @@ $(function () {
   }
 
   function handleTime() {
-    data.calculateTotalTime();
+    data.calculateTotalTime(); // This should trigger when display needs to update
   }
 
   //Displays appropriate sign in/out buttons on display 

--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -50,7 +50,7 @@ var data = {
     },
     timeObject: {},
     getTime: function() {
-        firebase.database().ref('time/users/' + auth.uid + "/" + this.timeInstance.id + "/")
+        firebase.database().ref('time/users/' + auth.uid + "/")
             .once('value', function (snapshot) {
                 data.timeObject = snapshot.val();
                 
@@ -60,10 +60,39 @@ var data = {
     },
     totalTime: "",
     calculateTotalTime: function() {
-        var start = moment(this.timeObject.start);
-        var stop = moment(this.timeObject.stop);
+        var keys = Object.keys(this.timeObject);
+        var i;
+        var j;
 
-        this.totalTime = stop.diff(start, "minutes");
-        console.log(stop.diff(start, "seconds"));
+        this.totalTime = 0;
+
+        if (keys.length === 1) {
+            if (this.timeObject.keys[0].stop !== undefined) {
+                this.totalTime += this.parseTimestamp(this.timeObject[keys[0]].start, this.timeObject[keys[0]].stop);
+            }
+            else {
+                console.log("null time: " + keys[0]);
+            }
+        }
+        else if (keys.length !== 0) {
+            for (i = 0, j = keys.length; i < j; i++) {
+                if (this.timeObject[keys[i]].stop !== undefined) {
+                    this.totalTime += this.parseTimestamp(this.timeObject[keys[i]].start, this.timeObject[keys[i]].stop);
+                }
+                else {
+                    console.log("null time: " + keys[i]);
+                }
+            }
+        }
+
+        console.log(this.totalTime + " seconds");
+    },
+    parseTimestamp: function(start, stop) {
+        start = moment(start);
+        stop = moment(stop);
+
+        timeDiff = stop.diff(start, "seconds");
+
+        return timeDiff;
     }
 }


### PR DESCRIPTION
Updated data.getTime() to fetch fall time instances and data.calculateTotalTime() to calculate total time from all time instances. 

Tony identified an issue where if the user does not click "stop," a timestamp will not be logged in Firebase. This is resolved by looking for "undefined" in the stop timestamp and not calculating time when no timestamp exists. Issue 66 suggests a solution.

data.calculateTotalTime() should trigger when the display needs to be updated. Currently issue 65. For proof of concept, it is embedded in the stop button.