### PR TITLE
Front end readable time data

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -4,11 +4,22 @@ $(function () {
     signOutListener: notificationService.addObserver('AUTH_SIGNOUT', this, handleSignOut),
     getTimeListener: notificationService.addObserver('TIME_FETCHED', this, handleTime),
     flockalogListener: notificationService.addObserver('DATA_FLOCKALOGS_DOWNLOADED', this, handleFlockalogDownload),
+    getEveryUserListener: notificationService.addObserver('USERS_FETCHED', this, handleEveryUser),
+    getAllTime: notificationService.addObserver('ALL_TIME_FETCHED', this, handleAllTime)
+  }
+
+  function handleEveryUser() {
+    data.getAllTime();
+  }
+
+  function handleAllTime() {
+    console.log(data)
   }
 
   function handleSignIn() {
     console.log('user signed in');
     signInDisplay();
+    data.getEveryUser();
   }
 
   function handleSignOut() {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -3,33 +3,23 @@ $(function () {
   var app = {
     authListener: notificationService.addObserver('AUTH_SIGNIN', this, handleSignIn),
     signOutListener: notificationService.addObserver('AUTH_SIGNOUT', this, handleSignOut),
-    getTimeListener: notificationService.addObserver('TIME_FETCHED', this, handleTime),
     flockalogListener: notificationService.addObserver('DATA_FLOCKALOGS_DOWNLOADED', this, handleFlockalogDownload),
-    getEveryUserListener: notificationService.addObserver('USERS_FETCHED', this, handleEveryUser),
-    getAllTime: notificationService.addObserver('ALL_TIME_FETCHED', this, handleAllTime)
+    getAllUsersListener: notificationService.addObserver('USERS_FETCHED', this, handleAllUsers)
   }
 
-  function handleEveryUser() {
+  function handleAllUsers() {
     data.getAllTime();
-  }
-
-  function handleAllTime() {
-    console.log(data)
   }
 
   function handleSignIn() {
     console.log('user signed in');
     signInDisplay();
-    data.getEveryUser();
+    data.getAllUsers();
   }
 
   function handleSignOut() {
     // call methods related to auth sign out
     signInDisplay();
-  }
-
-  function handleTime() {
-    data.calculateTotalTime(); // This should trigger when display needs to update
   }
 
   function handleFlockalogDownload() {
@@ -44,9 +34,9 @@ $(function () {
     //Pulling data for user daily time and calling function to display the bar graph
     var flockaDay = (data.getCurrentUserDailyFlockatime())
     for (i=0; i<flockaDay.length; i++){
-      console.log(flockaDay[i]);
+      // console.log(flockaDay[i]);
       flockaDayConverted = flockaDay[i].time.toFixed(2);
-      console.log(flockaDayConverted);
+      // console.log(flockaDayConverted);
       flockaDataset.push(flockaDayConverted);
     }
     barGraphDisplay();
@@ -174,7 +164,7 @@ $(function () {
     var state = $(this).attr("state");
     if (state === "active") {
       data.updateTime("stop");
-      data.getTime();
+      
       $(this).attr("state", "inactive");
       $(".codeTimeStart").attr("state", "active");
     }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -39,7 +39,7 @@ $(function () {
     var flockaTable = data.getFlockalogsLeaderboard();
     for (i = 0; i < flockaTable.length; i++) {
       leaderboardDisplay(i, flockaTable[i].username, flockaTable[i].total, flockaTable[i].dailyAvg);
-      console.log(flockaTable[i]);
+      // console.log(flockaTable[i]);
     }
     //Pulling data for user daily time and calling function to display the bar graph
     var flockaDay = (data.getCurrentUserDailyFlockatime())
@@ -273,7 +273,7 @@ function leaderboardDisplay(rank, userName, total, dailyAverage) {
   row.append(td2);
   row.append(td3);
   row.append(td4);
-  console.log(name);
+  // console.log(name);
 
   $("#leaderboardTableBody").append(row);
 }

--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -234,12 +234,12 @@ var data = {
 
     return timeDiff;
   },
-  determineThisWeek: function(timestamp) { // Determines how many days ago the time instance was
+  determineThisWeek: function (timestamp) { // Determines how many days ago the time instance was
     var dayDiff = moment().diff(timestamp, "days");
 
     return dayDiff;
   },
-  getAllTime: function() {
+  getAllTime: function () {
     firebase.database().ref('time/users/').once('value').then(function (snapshot) {
       data.allTime = snapshot.val();
 
@@ -248,13 +248,30 @@ var data = {
       notificationService.postNotification('ALL_TIME_FETCHED', null);
     });
   },
-  parseAllTime: function() {
-    console.log("every user:");
-    console.log(this.everyUser);
-    console.log("all time:")
-    console.log(this.allTime);
+  parseAllTime: function () {
+    var userKeys = Object.keys(this.everyUser);
+    var timeUserKeys = Object.keys(this.allTime);
+    var i;
+    var j;
+    var k = userKeys.length;
+    var l = timeUserKeys.length;
+    var payload = [];
+
+    for (i = 0; i < k; i++) {
+      for (j = 0; j < l; j++) {
+        if (userKeys[i] === userKeys[j]) {
+          payload.push(
+            {
+              dailyAvg: 0,
+              total: 0,
+              username: this.everyUser[userKeys[i]].email
+            });
+        }
+      }
+    }
+    console.log(payload);
   },
-  buildTableTimeData: function() {
+  buildTableTimeData: function () {
   },
   convertTime: function (hours) {
     // takes a floating point value representing hours and converts it to a string

--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -230,7 +230,7 @@ var data = {
     start = moment(start);
     stop = moment(stop);
 
-    var timeDiff = stop.diff(start, "minutes");
+    var timeDiff = stop.diff(start, "minutes", true);
 
     return timeDiff;
   },
@@ -261,19 +261,59 @@ var data = {
       for (j = 0; j < l; j++) {
         if (userKeys[i] === timeUserKeys[j]) {
           var timeObject = this.allTime[userKeys[i]];
-          // console.log("time obj" + userKeys[i])
-          // console.log(timeObject)
-          // this.parseTimestamp();
+          var totalTime = this.determineTotalTime(timeObject);
+          var avgTime = totalTime[0] / totalTime[1];
+
           payload.push(
             {
-              dailyAvg: 0,
-              total: 0,
+              dailyAvg: avgTime,
+              total: totalTime[0],
               username: this.everyUser[userKeys[i]].email
             });
         }
       }
     }
     console.log(payload);
+  },
+  determineTotalTime: function (timeObject) { // Calculates total time for the previous week and filters per day
+    var keys = Object.keys(timeObject);
+    var dayIndex = 0;
+    var i;
+    var j;
+    var totalTime = 0;
+    var days = 1;
+
+    if (keys.length === 1) { // If only one time instance exists, avoid executing the loop - this violates DRY, but to avoid scoping issues...
+      if (timeObject.keys[0].stop !== undefined) { // Protect against instance where no start timestamp exists
+        dayIndex = this.determineThisWeek(timeObject[keys[0]].start);
+        days = 1;
+
+        if (dayIndex < 7) {
+          totalTime += this.parseTimestamp(timeObject[keys[0]].start, timeObject[keys[0]].stop);
+        }
+      }
+      else {
+        console.log("null time: " + keys[0]);
+      }
+    }
+    else if (keys.length !== 0) {
+      for (i = 0, j = keys.length; i < j; i++) {
+
+        if (timeObject[keys[i]].stop !== undefined) {
+          dayIndex = this.determineThisWeek(timeObject[keys[i]].start);
+          days = 7;
+
+          if (dayIndex < 7) {
+            totalTime += this.parseTimestamp(timeObject[keys[i]].start, timeObject[keys[i]].stop);
+          }
+        }
+        else {
+          console.log("null time: " + keys[i]);
+        }
+      }
+    }
+
+    return [totalTime, days];
   },
   buildTableTimeData: function () {
   },

--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -184,8 +184,14 @@ var data = {
 
     var daysOfWeek = this.createWeek();
     var weekData = [];
+
+    var keys = [];
     
-    var keys = Object.keys(this.timeObject);
+    if ((this.timeObject !== undefined) &&
+        (this.timeObject !== null)) {
+          
+          keys = Object.keys(this.timeObject);
+    }
 
     var i;
     var j = keys.length;

--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -32,6 +32,7 @@ var data = {
   timeObject: {}, // Contains all time instances that user has tracked, fetched from Firebase
   timeLastWeek: new Array(7).fill(0), // Array that contains total time for each day, previous 7 days
   allTime: {}, // Object containing all time instances and child objects of those instances, by user
+  timeLastWeekNew: {},
   createTimeInstance: function () { // Creates a child on the time node in Firebase, per user
     this.timeInstance = database.ref("time/users/" + auth.uid + "/").push({}).key;
 
@@ -190,30 +191,21 @@ var data = {
   },
   calculateTotalTime: function () { // Calculates total time for the previous week and filters per day
     var keys = Object.keys(this.timeObject);
+    var lastWeekArray = new Array(7).fill(0);
     var dayIndex = 0;
+    var dayArray = [];
+    var lastWeek = [];
     var i;
     var j;
 
-    if (keys.length === 1) { // If only one time instance exists, avoid executing the loop - this violates DRY, but to avoid scoping issues...
-      if (this.timeObject.keys[0].stop !== undefined) { // Protect against instance where no start timestamp exists
-        dayIndex = this.determineThisWeek(this.timeObject[keys[0]].start);
-
-        if (dayIndex < 7) {
-          this.timeLastWeek[dayIndex] = this.parseTimestamp(this.timeObject[keys[0]].start, this.timeObject[keys[0]].stop);
-        }
-      }
-      else {
-        console.log("null time: " + keys[0]);
-      }
-    }
-    else if (keys.length !== 0) {
+    if (keys.length !== 0) { // If no time instance exists, avoid executing the loop
       for (i = 0, j = keys.length; i < j; i++) {
 
-        if (this.timeObject[keys[i]].stop !== undefined) {
+        if (this.timeObject[keys[i]].stop !== undefined) { // Protect against instance where no start timestamp exists
           dayIndex = this.determineThisWeek(this.timeObject[keys[i]].start);
 
           if (dayIndex < 7) {
-            this.timeLastWeek[dayIndex] += this.parseTimestamp(this.timeObject[keys[i]].start, this.timeObject[keys[i]].stop);
+            lastWeekArray[dayIndex] += this.parseTimestamp(this.timeObject[keys[i]].start, this.timeObject[keys[i]].stop);
           }
         }
         else {
@@ -222,9 +214,22 @@ var data = {
       }
     }
 
-    this.timeLastWeek = this.timeLastWeek.reverse(); // Make array in ascending days order
+    for (i = 0, j = 7; i < j; i++) {
+      dayArray[i] = moment().subtract(i, 'day').format("YYYY-MM-DD");
+    }
 
-    console.log(this.timeLastWeek + " minutes");
+    dayArray - dayArray.reverse();
+    lastWeekArray = lastWeekArray.reverse(); // Make array in ascending days order
+
+    for (i = 0, j = dayArray.length; i < j; i++) {
+      lastWeek[i] = {
+        time: lastWeekArray[i],
+        date: dayArray[i]
+      }
+    }
+
+    console.log(lastWeek);
+    console.log("minutes");
   },
   parseTimestamp: function (start, stop) { // Use Moment JS to determine the time between timestamps in minutes
     start = moment(start);

--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -262,7 +262,14 @@ var data = {
         if (userKeys[i] === timeUserKeys[j]) {
           var timeObject = this.allTime[userKeys[i]];
           var totalTime = this.determineTotalTime(timeObject);
-          var avgTime = totalTime[0] / totalTime[1];
+          var avgTime;
+
+          if (totalTime[1] === 0) {
+            avgTime = 0;
+          }
+          else {
+            avgTime = totalTime[0] / totalTime[1];
+          }
 
           payload.push(
             {
@@ -280,8 +287,11 @@ var data = {
     var dayIndex = 0;
     var i;
     var j;
+    var k;
+    var l;
     var totalTime = 0;
-    var days = 1;
+    var days = 0;
+    var timeArr = new Array(7).fill(0);
 
     if (keys.length === 1) { // If only one time instance exists, avoid executing the loop - this violates DRY, but to avoid scoping issues...
       if (timeObject.keys[0].stop !== undefined) { // Protect against instance where no start timestamp exists
@@ -289,7 +299,8 @@ var data = {
         days = 1;
 
         if (dayIndex < 7) {
-          totalTime += this.parseTimestamp(timeObject[keys[0]].start, timeObject[keys[0]].stop);
+          // totalTime = this.parseTimestamp(timeObject[keys[0]].start, timeObject[keys[0]].stop);
+          timeArr[dayIndex] = this.parseTimestamp(timeObject[keys[0]].start, timeObject[keys[0]].stop);
         }
       }
       else {
@@ -304,12 +315,20 @@ var data = {
           days = 7;
 
           if (dayIndex < 7) {
-            totalTime += this.parseTimestamp(timeObject[keys[i]].start, timeObject[keys[i]].stop);
+            // totalTime += this.parseTimestamp(timeObject[keys[i]].start, timeObject[keys[i]].stop);
+            timeArr[dayIndex] += this.parseTimestamp(timeObject[keys[i]].start, timeObject[keys[i]].stop);
           }
         }
         else {
           console.log("null time: " + keys[i]);
         }
+      }
+    }
+
+    for (k = 0, l = timeArr.length; k < l; k++) {
+      if (timeArr[k] !== 0) {
+        days++;
+        totalTime += timeArr[k];
       }
     }
 

--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -19,9 +19,18 @@ var data = {
   createUser: function (email) {
     database.ref("users/" + auth.uid + "/").set(email);
   },
+  everyUser: {}, // Object containing all users and child objects of those users
+  getEveryUser: function () {
+    firebase.database().ref('/users').once('value').then(function (snapshot) {
+      data.everyUser = snapshot.val();
+
+      notificationService.postNotification('USERS_FETCHED', null);
+    });
+  },
   timeInstance: "", // Id that represents an instance of user tracking their time 
   timeObject: {}, // Contains all time instances that user has tracked, fetched from Firebase
   timeLastWeek: new Array(7).fill(0), // Array that contains total time for each day, previous 7 days
+  allTime: {}, // Object containing all time instances and child objects of those instances, by user
   createTimeInstance: function () { // Creates a child on the time node in Firebase, per user
     this.timeInstance = database.ref("time/users/" + auth.uid + "/").push({}).key;
 
@@ -183,7 +192,7 @@ var data = {
     var i;
     var j;
 
-    if (keys.length === 1) { // If only one time instance exists, avoid executing the loop
+    if (keys.length === 1) { // If only one time instance exists, avoid executing the loop - this violates DRY, but to avoid scoping issues...
       if (this.timeObject.keys[0].stop !== undefined) { // Protect against instance where no start timestamp exists
         dayIndex = this.determineThisWeek(this.timeObject[keys[0]].start);
 
@@ -227,6 +236,23 @@ var data = {
     var dayDiff = moment().diff(timestamp, "days");
 
     return dayDiff;
+  },
+  getAllTime: function() {
+    firebase.database().ref('time/users/').once('value').then(function (snapshot) {
+      data.allTime = snapshot.val();
+
+      data.parseAllTime();
+
+      notificationService.postNotification('ALL_TIME_FETCHED', null);
+    });
+  },
+  parseAllTime: function() {
+    console.log("every user:");
+    console.log(this.everyUser);
+    console.log("all time:")
+    console.log(this.allTime);
+  },
+  buildTableTimeData: function() {
   },
   convertTime: function (hours) {
     // takes a floating point value representing hours and converts it to a string

--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -259,7 +259,11 @@ var data = {
 
     for (i = 0; i < k; i++) {
       for (j = 0; j < l; j++) {
-        if (userKeys[i] === userKeys[j]) {
+        if (userKeys[i] === timeUserKeys[j]) {
+          var timeObject = this.allTime[userKeys[i]];
+          // console.log("time obj" + userKeys[i])
+          // console.log(timeObject)
+          // this.parseTimestamp();
           payload.push(
             {
               dailyAvg: 0,


### PR DESCRIPTION
Refactored all of the time calculations to pass a data in formats that the display takes in. 

Added data methods:
* `getAllTime` to retrieve all time data
* `parseAllTime` in order to build an array of objects that contains username, total, and dailyAvg
  * results from console:
```
0: {dailyAvg: 0, total: 0, username: "andrew@aljweb.com"}
1: {dailyAvg: 0.008333333333333333, total: 0.06666666666666667, username: "crystal.nassouri@gmail.com"}
2: {dailyAvg: 0.029166666666666667, total: 0.23333333333333334, username: "alexbcahn@gmail.com"}
3: {dailyAvg: 9.622222222222224, total: 86.60000000000001, username: "jlouie10@gmail.com"}
```
* `determineTotalTime` to calculate values for `parseAllTime`

Updated previous `calculateTotalTime` to `calculatePersonalTime` and formatted to display's liking, results from console:
```
0: {time: 0, date: "2019-04-27"}
1: {time: 0, date: "2019-04-28"}
2: {time: 0, date: "2019-04-29"}
3: {time: 0, date: "2019-04-30"}
4: {time: 0, date: "2019-05-01"}
5: {time: 0.13333333333333333, date: "2019-05-02"}
6: {time: 86.46666666666667, date: "2019-05-03"}
```

